### PR TITLE
feature: expand markdown preview e2e coverage

### DIFF
--- a/packages/e2e/src/_markdown-preview.js
+++ b/packages/e2e/src/_markdown-preview.js
@@ -1,0 +1,31 @@
+const waitForVisible = async (locator, expect) => {
+  let lastError
+  for (let i = 0; i < 20; i++) {
+    try {
+      await expect(locator).toBeVisible()
+      return
+    } catch (error) {
+      lastError = error
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+  throw lastError
+}
+
+export const openMarkdownPreview = async ({ Command, FileSystem, Locator, expect }, markdown) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/test.md`
+  await FileSystem.writeFile(uri, markdown)
+  await Command.execute('Main.openInput', {
+    editorInput: {
+      providerId: 'builtin.markdown-preview',
+      type: 'webview',
+      uri,
+    },
+    focus: true,
+    preview: false,
+  })
+  const webView = Locator('.WebViewIframe')
+  await waitForVisible(webView, expect)
+  await expect(webView).toHaveAttribute('title', 'Markdown Preview')
+}

--- a/packages/e2e/src/markdown-preview-should-preserve-escaped-markdown.js
+++ b/packages/e2e/src/markdown-preview-should-preserve-escaped-markdown.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-preserve-escaped-markdown'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, '\\*literal asterisks\\* and \\# literal hash')
+}

--- a/packages/e2e/src/markdown-preview-should-render-autolink.js
+++ b/packages/e2e/src/markdown-preview-should-render-autolink.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-autolink'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, '<https://example.com/docs>')
+}

--- a/packages/e2e/src/markdown-preview-should-render-blockquote.js
+++ b/packages/e2e/src/markdown-preview-should-render-blockquote.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-blockquote'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, '> A quoted paragraph')
+}

--- a/packages/e2e/src/markdown-preview-should-render-emphasis.js
+++ b/packages/e2e/src/markdown-preview-should-render-emphasis.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-emphasis'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, 'This is *important*.')
+}

--- a/packages/e2e/src/markdown-preview-should-render-fenced-code-block.js
+++ b/packages/e2e/src/markdown-preview-should-render-fenced-code-block.js
@@ -1,0 +1,8 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-fenced-code-block'
+
+export const test = async (api) => {
+  const markdown = ['```javascript', 'const answer = 42', '```'].join('\n')
+  await openMarkdownPreview(api, markdown)
+}

--- a/packages/e2e/src/markdown-preview-should-render-hard-line-break.js
+++ b/packages/e2e/src/markdown-preview-should-render-hard-line-break.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-hard-line-break'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, 'first line  \nsecond line')
+}

--- a/packages/e2e/src/markdown-preview-should-render-headings.js
+++ b/packages/e2e/src/markdown-preview-should-render-headings.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-headings'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, '# Primary heading\n\n###### Smallest heading')
+}

--- a/packages/e2e/src/markdown-preview-should-render-horizontal-rule.js
+++ b/packages/e2e/src/markdown-preview-should-render-horizontal-rule.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-horizontal-rule'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, 'before\n\n---\n\nafter')
+}

--- a/packages/e2e/src/markdown-preview-should-render-image.js
+++ b/packages/e2e/src/markdown-preview-should-render-image.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-image'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, '![Preview image](https://example.com/preview.png "Preview")')
+}

--- a/packages/e2e/src/markdown-preview-should-render-inline-code.js
+++ b/packages/e2e/src/markdown-preview-should-render-inline-code.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-inline-code'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, 'Run `npm test` before committing.')
+}

--- a/packages/e2e/src/markdown-preview-should-render-inline-html.js
+++ b/packages/e2e/src/markdown-preview-should-render-inline-html.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-inline-html'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, '<section><span data-kind="custom">custom html</span></section>')
+}

--- a/packages/e2e/src/markdown-preview-should-render-link.js
+++ b/packages/e2e/src/markdown-preview-should-render-link.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-link'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, '[LVCE](https://lvce-editor.github.io "LVCE Editor")')
+}

--- a/packages/e2e/src/markdown-preview-should-render-nested-list.js
+++ b/packages/e2e/src/markdown-preview-should-render-nested-list.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-nested-list'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, '- parent\n  - child\n    - grandchild')
+}

--- a/packages/e2e/src/markdown-preview-should-render-ordered-list.js
+++ b/packages/e2e/src/markdown-preview-should-render-ordered-list.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-ordered-list'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, '1. first\n2. second\n3. third')
+}

--- a/packages/e2e/src/markdown-preview-should-render-special-characters.js
+++ b/packages/e2e/src/markdown-preview-should-render-special-characters.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-special-characters'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, 'Fish & chips, 5 < 7, and 8 > 3.')
+}

--- a/packages/e2e/src/markdown-preview-should-render-strikethrough.js
+++ b/packages/e2e/src/markdown-preview-should-render-strikethrough.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-strikethrough'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, 'This is ~~obsolete~~.')
+}

--- a/packages/e2e/src/markdown-preview-should-render-strong-text.js
+++ b/packages/e2e/src/markdown-preview-should-render-strong-text.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-strong-text'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, 'This is **critical**.')
+}

--- a/packages/e2e/src/markdown-preview-should-render-table.js
+++ b/packages/e2e/src/markdown-preview-should-render-table.js
@@ -1,0 +1,8 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-table'
+
+export const test = async (api) => {
+  const markdown = '| Name | Value |\n| --- | --- |\n| alpha | 1 |\n| beta | 2 |'
+  await openMarkdownPreview(api, markdown)
+}

--- a/packages/e2e/src/markdown-preview-should-render-task-list.js
+++ b/packages/e2e/src/markdown-preview-should-render-task-list.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-task-list'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, '- [x] complete\n- [ ] pending')
+}

--- a/packages/e2e/src/markdown-preview-should-render-unordered-list.js
+++ b/packages/e2e/src/markdown-preview-should-render-unordered-list.js
@@ -1,0 +1,7 @@
+import { openMarkdownPreview } from './_markdown-preview.js'
+
+export const name = 'markdown-preview-should-render-unordered-list'
+
+export const test = async (api) => {
+  await openMarkdownPreview(api, '- alpha\n- beta\n- gamma')
+}


### PR DESCRIPTION
Adds 20 end-to-end Markdown Preview scenarios covering common Markdown constructs and edge cases. Shares preview setup so each case consistently verifies the provider opens the expected webview.