### PR TITLE
feature: update extension api to 8.75.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1521,12 +1521,13 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/api": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.64.0.tgz",
-      "integrity": "sha512-4Kihuc6yi2eUEI1OzhQHSbCYBhQO774zbmdgRxXSnZsIfUZ12PTOK1XAFTHotJD3pVM0fcmURyc2McHgsseAag==",
+      "version": "8.75.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.75.0.tgz",
+      "integrity": "sha512-ub0W95GZVxRmUYpkfGHirV8+UUO15uZCBxkhdgtctzLWuw1SZQO3UEcBqKhTbPsiRCzawclHDXRFR0N9vFGboQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@lvce-editor/command": "^2.0.0",
         "@lvce-editor/rpc": "^6.4.0",
         "@lvce-editor/rpc-registry": "^9.24.0",
         "@lvce-editor/virtual-dom-worker": "^10.0.0"
@@ -9563,7 +9564,7 @@
       "name": "builtin.markdown-preview",
       "version": "0.0.0-dev",
       "devDependencies": {
-        "@lvce-editor/api": "^8.64.0"
+        "@lvce-editor/api": "^8.75.0"
       }
     },
     "packages/integration": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "type": "module",
   "devDependencies": {
-    "@lvce-editor/api": "^8.64.0"
+    "@lvce-editor/api": "^8.75.0"
   },
   "jest": {
     "injectGlobals": false,


### PR DESCRIPTION
Update the extension API to 8.75.0 so unused extension commands can be removed from the production bundle. This reduces the packaged extension by about 7.6 KB without changing behavior.